### PR TITLE
Update waiters to ManualResetEventSlim for synchronous waiters

### DIFF
--- a/AsyncSharp.Test/AsyncSemaphoreTests.cs
+++ b/AsyncSharp.Test/AsyncSemaphoreTests.cs
@@ -213,7 +213,7 @@ namespace AsyncSharp.Test
             Assert.True(timeWaited > TimeSpan.FromMilliseconds(100));
         }
 
-        [Fact(Skip = "Hangs forever due to CancellationToken only being checked at beginning.")]
+        [Fact]
         public void Wait_CancellationToken_Success()
         {
             var semaphore = new AsyncSemaphore(0, 1);


### PR DESCRIPTION
Gives a performance advantage for short-lived waiters and adds support for cancellation tokens to synchronous waits.