### PR TITLE
Update from int to TimeSpan for timeouts and Fix timeout usage in Wait(...) to be more accurate

### DIFF
--- a/AsyncSharp.Test/AsyncMutexTests.cs
+++ b/AsyncSharp.Test/AsyncMutexTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -32,7 +30,7 @@ namespace AsyncSharp.Test
             mutex.Lock();
 
             var start = Environment.TickCount;
-            var capturedLock = mutex.Lock(100);
+            var capturedLock = mutex.Lock(TimeSpan.FromMilliseconds(100));
 
             Assert.False(capturedLock);
             Assert.True(Environment.TickCount - start >= 90);
@@ -45,7 +43,7 @@ namespace AsyncSharp.Test
             mutex.Lock();
 
             var start = Environment.TickCount;
-            var capturedLock = await mutex.LockAsync(100);
+            var capturedLock = await mutex.LockAsync(TimeSpan.FromMilliseconds(100));
 
             Assert.False(capturedLock);
             Assert.True(Environment.TickCount - start >= 90);
@@ -87,7 +85,7 @@ namespace AsyncSharp.Test
             using var mutex = new AsyncMutex();
             using (mutex.LockAndUnlock())
             {
-                Assert.False(mutex.Lock(0));
+                Assert.False(mutex.Lock(TimeSpan.FromMilliseconds(0)));
             }
         }
 
@@ -97,7 +95,7 @@ namespace AsyncSharp.Test
             using var mutex = new AsyncMutex();
             using (await mutex.LockAndUnlockAsync())
             {
-                Assert.False(await mutex.LockAsync(0));
+                Assert.False(await mutex.LockAsync(TimeSpan.FromMilliseconds(0)));
             }
         }
     }

--- a/AsyncSharp.Test/AsyncSemaphoreTests.cs
+++ b/AsyncSharp.Test/AsyncSemaphoreTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +14,7 @@ namespace AsyncSharp.Test
             using var semaphore = new AsyncSemaphore(1, 1, true);
 
             semaphore.Wait();
-            var acquiredLock = semaphore.Wait(1, 0);
+            var acquiredLock = semaphore.Wait(1, TimeSpan.FromMilliseconds(0));
             
             Assert.False(acquiredLock);
         }
@@ -26,7 +25,7 @@ namespace AsyncSharp.Test
             using var semaphore = new AsyncSemaphore(1, 1, true);
 
             await semaphore.WaitAsync();
-            var acquiredLock = await semaphore.WaitAsync(1, 0);
+            var acquiredLock = await semaphore.WaitAsync(1, TimeSpan.FromMilliseconds(0));
 
             Assert.False(acquiredLock);
         }
@@ -66,11 +65,11 @@ namespace AsyncSharp.Test
             {
                 var maxToAcquire = amountLeft / 2;
                 var amountToAcquire = random.Next(1, maxToAcquire > 1 ? maxToAcquire : 1);
-                Assert.True(semaphore.Wait(amountToAcquire, 0));
+                Assert.True(semaphore.Wait(amountToAcquire, TimeSpan.FromMilliseconds(0)));
                 amountLeft -= amountToAcquire;
             }
             semaphore.Release(1000);
-            Assert.True(semaphore.Wait(1000, 0));
+            Assert.True(semaphore.Wait(1000, TimeSpan.FromMilliseconds(0)));
         }
 
         [Fact]
@@ -84,11 +83,11 @@ namespace AsyncSharp.Test
             {
                 var maxToAcquire = amountLeft / 2;
                 var amountToAcquire = random.Next(1, maxToAcquire > 1 ? maxToAcquire : 1);
-                Assert.True(await semaphore.WaitAsync(amountToAcquire, 0));
+                Assert.True(await semaphore.WaitAsync(amountToAcquire, TimeSpan.FromMilliseconds(0)));
                 amountLeft -= amountToAcquire;
             }
             semaphore.Release(1000);
-            Assert.True(await semaphore.WaitAsync(1000, 0));
+            Assert.True(await semaphore.WaitAsync(1000, TimeSpan.FromMilliseconds(0)));
         }
 
         [Fact]
@@ -96,9 +95,9 @@ namespace AsyncSharp.Test
         {
             using var semaphore = new AsyncSemaphore(0, 10, true);
 
-            var acquiredWhenNoneAvailable = semaphore.Wait(10, 0);
+            var acquiredWhenNoneAvailable = semaphore.Wait(10, TimeSpan.FromMilliseconds(0));
             semaphore.ReleaseAll();
-            var acquiredWhenAllAvailable = semaphore.Wait(10, 0);
+            var acquiredWhenAllAvailable = semaphore.Wait(10, TimeSpan.FromMilliseconds(0));
 
             Assert.False(acquiredWhenNoneAvailable);
             Assert.True(acquiredWhenAllAvailable);
@@ -109,9 +108,9 @@ namespace AsyncSharp.Test
         {
             using var semaphore = new AsyncSemaphore(0, 5, true);
 
-            var acquiredWhenNoneAvailable = semaphore.Wait(5, 0);
+            var acquiredWhenNoneAvailable = semaphore.Wait(5, TimeSpan.FromMilliseconds(0));
             semaphore.Release(5);
-            var acquiredWhenAllAvailable = semaphore.Wait(5, 0);
+            var acquiredWhenAllAvailable = semaphore.Wait(5, TimeSpan.FromMilliseconds(0));
 
             Assert.False(acquiredWhenNoneAvailable);
             Assert.True(acquiredWhenAllAvailable);
@@ -194,7 +193,7 @@ namespace AsyncSharp.Test
         {
             var startTime = Environment.TickCount;
             using var semaphore = new AsyncSemaphore(0, 1);
-            var acquiredSemaphore = semaphore.Wait(1, 250);
+            var acquiredSemaphore = semaphore.Wait(1, TimeSpan.FromMilliseconds(250));
             var timeWaited = Environment.TickCount - startTime;
 
             Assert.False(acquiredSemaphore);
@@ -206,7 +205,7 @@ namespace AsyncSharp.Test
         {
             var startTime = Environment.TickCount;
             using var semaphore = new AsyncSemaphore(0, 1);
-            var acquiredSemaphore = await semaphore.WaitAsync(1, 100);
+            var acquiredSemaphore = await semaphore.WaitAsync(1, TimeSpan.FromMilliseconds(100));
             var timeWaited = Environment.TickCount - startTime;
 
             Assert.False(acquiredSemaphore);
@@ -224,13 +223,13 @@ namespace AsyncSharp.Test
                 Task<bool> prioritySemaphoreWaiter;
                 if (currentOrder)
                 {
-                    normalSemaphoreWaiter = semaphore.WaitAsync(1, Timeout.Infinite, AsyncSemaphore.DefaultPriority, CancellationToken.None);
-                    prioritySemaphoreWaiter = semaphore.WaitAsync(1, Timeout.Infinite, AsyncSemaphore.DefaultPriority+1, CancellationToken.None);
+                    normalSemaphoreWaiter = semaphore.WaitAsync(1, Timeout.InfiniteTimeSpan, AsyncSemaphore.DefaultPriority, CancellationToken.None);
+                    prioritySemaphoreWaiter = semaphore.WaitAsync(1, Timeout.InfiniteTimeSpan, AsyncSemaphore.DefaultPriority+1, CancellationToken.None);
                 }
                 else
                 {
-                    prioritySemaphoreWaiter = semaphore.WaitAsync(1, Timeout.Infinite, AsyncSemaphore.DefaultPriority+1, CancellationToken.None);
-                    normalSemaphoreWaiter = semaphore.WaitAsync(1, Timeout.Infinite, AsyncSemaphore.DefaultPriority, CancellationToken.None);
+                    prioritySemaphoreWaiter = semaphore.WaitAsync(1, Timeout.InfiniteTimeSpan, AsyncSemaphore.DefaultPriority+1, CancellationToken.None);
+                    normalSemaphoreWaiter = semaphore.WaitAsync(1, Timeout.InfiniteTimeSpan, AsyncSemaphore.DefaultPriority, CancellationToken.None);
                 }
                 currentOrder = !currentOrder;
                 semaphore.Release(1);

--- a/AsyncSharp.Test/ReadersWriterAsyncLockTests.cs
+++ b/AsyncSharp.Test/ReadersWriterAsyncLockTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;

--- a/AsyncSharp/AsyncMutex.cs
+++ b/AsyncSharp/AsyncMutex.cs
@@ -48,7 +48,7 @@ namespace AsyncSharp
         /// Synchronously acquires lock.
         /// </summary>
         /// <param name="timeout"></param>
-        public bool Lock(int timeout)
+        public bool Lock(TimeSpan timeout)
             => _asyncSemaphore.Wait(1, timeout);
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace AsyncSharp
         /// </summary>
         /// <param name="timeout"></param>
         /// <param name="cancellationToken"></param>
-        public bool Lock(int timeout, CancellationToken cancellationToken)
+        public bool Lock(TimeSpan timeout, CancellationToken cancellationToken)
             => _asyncSemaphore.Wait(1, timeout, cancellationToken);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace AsyncSharp
         /// </summary>
         /// <param name="timeout"></param>
         /// <returns></returns>
-        public Task<bool> LockAsync(int timeout)
+        public Task<bool> LockAsync(TimeSpan timeout)
             => _asyncSemaphore.WaitAsync(1, timeout);
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace AsyncSharp
         /// <param name="timeout"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task<bool> LockAsync(int timeout, CancellationToken cancellationToken)
+        public Task<bool> LockAsync(TimeSpan timeout, CancellationToken cancellationToken)
             => _asyncSemaphore.WaitAsync(1, timeout, cancellationToken);
 
         /// <summary>

--- a/AsyncSharp/AsyncSharp.csproj
+++ b/AsyncSharp/AsyncSharp.csproj
@@ -17,7 +17,7 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <DebugType>portable</DebugType>
-        <Version>1.4.1</Version>
+        <Version>1.4.2</Version>
     </PropertyGroup>
     <ItemGroup>
         <None Include="..\LICENSE">

--- a/README.md
+++ b/README.md
@@ -101,28 +101,28 @@ AsyncMutex provides similar functionality to AsyncSemaphore, but only allows for
  * Async locking example:
 ```csharp
 using var mutex = new AsyncMutex();
-await semaphore.LockAsync();
+await mutex.LockAsync();
 try 
 {
     // Your operation
 }
 finally
 {
-    semaphore.Unlock();
+    mutex.Unlock();
 }
 ```
 
  * Synchronous locking example:
 ```csharp
 using var mutex = new AsyncMutex();
-semaphore.Lock();
+mutex.Lock();
 try 
 {
     // Your operation
 }
 finally
 {
-    semaphore.Unlock();
+    mutex.Unlock();
 }
 ```
 


### PR DESCRIPTION
The timeout resolution for Environment.Ticks is 16ms and other options are not going to be higher resolution than the time cost of a few lines of code running, so no reason to use it. Also removed unused namespace usings and fixed a few typos in the readme.